### PR TITLE
Changed `manifest.json`

### DIFF
--- a/divider.sketchplugin/Contents/Sketch/manifest.json
+++ b/divider.sketchplugin/Contents/Sketch/manifest.json
@@ -18,5 +18,5 @@
 	"version": "0.1",
 	"description": "divide selected",
 	"authorEmail": "jawa.yang@gmail.com",
-	"name": "Divider"
+	"name": "Sketch Divider"
 }

--- a/divider.sketchplugin/Contents/Sketch/manifest.json
+++ b/divider.sketchplugin/Contents/Sketch/manifest.json
@@ -18,5 +18,5 @@
 	"version": "0.1",
 	"description": "divide selected",
 	"authorEmail": "jawa.yang@gmail.com",
-	"name": "base64"
+	"name": "Divider"
 }


### PR DESCRIPTION
The plugin is displaying as `base64` inside of Sketch - **Updated** name to `Sketch Divider`
